### PR TITLE
Rigcol

### DIFF
--- a/thermosteam/_multi_stream.py
+++ b/thermosteam/_multi_stream.py
@@ -931,6 +931,20 @@ class MultiStream(Stream):
     
     ### Equilibrium ###
     
+    # @property
+    # def equilibrium(self):
+    #     """[Equilibrium] An object that can perform equilibrium on the stream."""
+    #     phases = self.phases
+    #     if phases == ('g', 'l'):
+    #         cache = self._vle_cache
+    #     elif phases == ('l', 'L'):
+    #         cache = self._lle_cache
+    #     elif phases == ('l', 's'):
+    #         cache = self._sle_cache
+    #     else:
+    #         return None
+    #     return cache.retrieve()
+        
     @property
     def vle(self):
         """[VLE] An object that can perform vapor-liquid equilibrium on the stream."""

--- a/thermosteam/equilibrium/lle.py
+++ b/thermosteam/equilibrium/lle.py
@@ -103,7 +103,7 @@ class LLE(Equilibrium, phases='lL'):
         self.temperature_cache_tolerance = temperature_cache_tolerance
         self._lle_chemicals = None
     
-    def __call__(self, T, P=None, top_chemical=None):
+    def __call__(self, T, P=None, l_chemical=None):
         """
         Perform liquid-liquid equilibrium.
 
@@ -113,7 +113,7 @@ class LLE(Equilibrium, phases='lL'):
             Operating temperature [K].
         P : float, optional
             Operating pressure [Pa].
-        top_chemical : str, optional
+        l_chemical : str, optional
             Identifier of chemical that will be favored in the "liquid" phase.
             
         """
@@ -138,14 +138,14 @@ class LLE(Equilibrium, phases='lL'):
                 mol_L = solve_lle_liquid_mol(mol, T, gamma.f, gamma.args,
                                              **self.differential_evolution_options)
                 mol_l = mol - mol_L
-                if top_chemical:
+                if l_chemical:
                     MW = self.chemicals.MW[index]
                     mass_L = mol_L * MW
                     mass_l = mol_l * MW
                     IDs = {i.ID: n for n, i in enumerate(lle_chemicals)}
-                    top_chemical_index = IDs[top_chemical]
-                    C_L = mass_L[top_chemical_index] / mass_L.sum()
-                    C_l = mass_l[top_chemical_index] / mass_l.sum()
+                    l_chemical_index = IDs[l_chemical]
+                    C_L = mass_L[l_chemical_index] / mass_L.sum()
+                    C_l = mass_l[l_chemical_index] / mass_l.sum()
                     top_L = C_L > C_l
                     if top_L: mol_l, mol_L = mol_L, mol_l
                 F_mol_l = mol_l.sum()

--- a/thermosteam/equilibrium/lle.py
+++ b/thermosteam/equilibrium/lle.py
@@ -72,7 +72,8 @@ class LLE(Equilibrium, phases='lL'):
     >>> settings.set_thermo(['Water', 'Ethanol', 'Octane', 'Hexane'], cache=True)
     >>> imol = indexer.MolarFlowIndexer(
     ...             l=[('Water', 304), ('Ethanol', 30)],
-    ...             L=[('Octane', 40), ('Hexane', 1)])
+    ...             L=[('Octane', 40), ('Hexane', 1)]
+    ...)
     >>> lle = equilibrium.LLE(imol)
     >>> lle(T=360)
     >>> lle
@@ -96,14 +97,14 @@ class LLE(Equilibrium, phases='lL'):
                                       'tol': 0.002}
     
     def __init__(self, imol=None, thermal_condition=None, thermo=None,
-                 composition_cache_tolerance=1e-6,
-                 temperature_cache_tolerance=1e-6):
+                 composition_cache_tolerance=1e-5,
+                 temperature_cache_tolerance=1e-3):
         super().__init__(imol, thermal_condition, thermo)
         self.composition_cache_tolerance = composition_cache_tolerance
         self.temperature_cache_tolerance = temperature_cache_tolerance
         self._lle_chemicals = None
     
-    def __call__(self, T, P=None, l_chemical=None):
+    def __call__(self, T, P=None, top_chemical=None):
         """
         Perform liquid-liquid equilibrium.
 
@@ -113,8 +114,8 @@ class LLE(Equilibrium, phases='lL'):
             Operating temperature [K].
         P : float, optional
             Operating pressure [Pa].
-        l_chemical : str, optional
-            Identifier of chemical that will be favored in the "liquid" phase.
+        top_chemical : str, optional
+            Identifier of chemical that will be favored in the "LIQUID" phase.
             
         """
         thermal_condition = self._thermal_condition
@@ -129,7 +130,7 @@ class LLE(Equilibrium, phases='lL'):
                 and T - self._T < self.temperature_cache_tolerance 
                 and (self._z_mol - z_mol < self.composition_cache_tolerance).all()):
                 K = self._K 
-                phi = phase_fraction(z_mol, K, self._phi)
+                self._phi = phi = phase_fraction(z_mol, K, self._phi)
                 y = z_mol * K / (phi * K + (1 - phi))
                 mol_l = y * phi * F_mol
                 mol_L = mol - mol_l
@@ -138,24 +139,23 @@ class LLE(Equilibrium, phases='lL'):
                 mol_L = solve_lle_liquid_mol(mol, T, gamma.f, gamma.args,
                                              **self.differential_evolution_options)
                 mol_l = mol - mol_L
-                if l_chemical:
+                if top_chemical:
                     MW = self.chemicals.MW[index]
                     mass_L = mol_L * MW
                     mass_l = mol_l * MW
                     IDs = {i.ID: n for n, i in enumerate(lle_chemicals)}
-                    l_chemical_index = IDs[l_chemical]
-                    C_L = mass_L[l_chemical_index] / mass_L.sum()
-                    C_l = mass_l[l_chemical_index] / mass_l.sum()
-                    top_L = C_L > C_l
-                    if top_L: mol_l, mol_L = mol_L, mol_l
+                    top_chemical_index = IDs[top_chemical]
+                    C_L = mass_L[top_chemical_index] / mass_L.sum()
+                    C_l = mass_l[top_chemical_index] / mass_l.sum()
+                    if C_L < C_l: mol_l, mol_L = mol_L, mol_l
                 F_mol_l = mol_l.sum()
                 z_mol_l = mol_l / F_mol_l
                 F_mol_L = mol_L.sum()
                 z_mol_L = mol_L / F_mol_L
                 z_mol_L[z_mol_L < 1e-16] = 1e-16
-                K = z_mol_l / z_mol_L
+                K = z_mol_L / z_mol_l
                 self._K = K
-                self._phi = F_mol_l / (F_mol_l + F_mol_L)
+                self._phi = F_mol_L / (F_mol_L + F_mol_l)
                 self._lle_chemicals = lle_chemicals
                 self._z_mol = z_mol
                 self._T = T

--- a/thermosteam/equilibrium/vle.py
+++ b/thermosteam/equilibrium/vle.py
@@ -423,7 +423,7 @@ class VLE(Equilibrium, phases='lg'):
     @property
     def thermal_condition(self):
         return self._thermal_condition
-
+    
     ### Single component equilibrium case ###
         
     def _set_thermal_condition_chemical(self, T, P):

--- a/thermosteam/reaction/_reaction.py
+++ b/thermosteam/reaction/_reaction.py
@@ -389,7 +389,10 @@ class Reaction:
         if tmo.reaction.CHECK_FEASIBILITY:
             negatives = values < 0.
             if negatives.any():
-                if values[negatives].sum() < -1e-16:
+                if values[negatives].sum() < -1e-12:
+                    X_net = self.X_net()
+                    for ID, X in X_net.items():
+                        if X > 1.: RuntimeError(f"conversion of '{ID}' is over 100%")
                     raise InfeasibleRegion('not enough reactants; reaction conversion')
                 else:
                     values[negatives] = 0.


### PR DESCRIPTION
Updates to mixer settlers:

* Allow for feeds at different stages (more than 2 feeds is now possible).
* Allow for extract and raffinate side draws.
* Faster (twice as fast given partition coefficients) simulation by implementing Thomas algorithm for solving tridiagonal matrix (in mass and equilibrium balances).
* Closure of overall mass balance (absolute zero generation/consumption of components regardless or convergence tolerance).
* **Partition data now given in the form of Extract/Raffinate** (instead of Raffinate/Extract).