### PR TITLE
fix function calls to legacy `solve_T`

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -227,9 +227,22 @@ def test_multistream():
     stream = tmo.MultiStream(None, l=[('Water', 1)], T=300, units='g/s')
     assert stream.get_flow('g/s', 'Water') == stream.F_mass / 3.6 == 1.
     stream.empty()    
+
+def test_mixture():
+    tmo.settings.set_thermo(['Water'], cache=True)
+
+    # test solve_T_at_xx
+    T_expected = 298
+    s5 = tmo.Stream('s5', T=T_expected, P=1e5, Water=1)
+    Th = s5.mixture.solve_T_at_HP(phase=s5.phase, mol=s5.mol, H=s5.H, T_guess=s5.T, P=s5.P)
+    assert_allclose(T_expected, Th, rtol=1e-3)
+    Ts = s5.mixture.solve_T_at_SP(phase=s5.phase, mol=s5.mol, S=s5.S, T_guess=s5.T, P=s5.P)
+    assert_allclose(T_expected, Ts, rtol=1e-3)
+    pass
     
 if __name__ == '__main__':
     test_stream()
     test_multistream()
     test_vlle()
     test_critical()
+    test_mixture()

--- a/thermosteam/_stream.py
+++ b/thermosteam/_stream.py
@@ -1029,7 +1029,7 @@ class Stream:
         if not h and self.isempty(): return
         z_mol = self.z_mol
         try: 
-            self.T = self.mixture.solve_T_at(
+            self.T = self.mixture.solve_T_at_HP(
                 self.phase, z_mol, h, *self._thermal_condition
             )
         except Exception as error: # pragma: no cover
@@ -1042,7 +1042,7 @@ class Stream:
                 self.phase = 'g'
             else:
                 raise error
-            self.T = self.mixture.solve_T(
+            self.T = self.mixture.solve_T_at_HP(
                 self.phase, z_mol, h, *self._thermal_condition
             )
             

--- a/thermosteam/equilibrium/sle.py
+++ b/thermosteam/equilibrium/sle.py
@@ -280,7 +280,7 @@ class SLE(Equilibrium, phases='ls'):
                     return mixture.xsolve_T(phase_data, H, T, P)
                 
                 self._thermal_condition.T = T = flx.aitken(
-                    f, mixture.xsolve_T(phase_data, H, T, P), 
+                    f, mixture.xsolve_T_at_HP(phase_data, H, T, P),
                     1e-3, (), 50, checkiter=False
                 )
             else:

--- a/thermosteam/mixture/mixture.py
+++ b/thermosteam/mixture/mixture.py
@@ -346,9 +346,9 @@ class Mixture:
         args = (H, self.xH, phase_mol, P, self.xCn(phase_mol, T_guess))
         return flx.aitken(xiter_T_at_HP, T_guess, 1e-6, args, 50, checkiter=False)
     
-    def solve_T_at_SP(self, phase, mol, H, T_guess, P):
+    def solve_T_at_SP(self, phase, mol, S, T_guess, P):
         """Solve for temperature in Kelvin."""
-        args = (H, self.H, phase, mol, P, self.Cn(phase, mol, T_guess))
+        args = (S, self.S, phase, mol, P, self.Cn(phase, mol, T_guess))
         return flx.aitken(iter_T_at_SP, T_guess, 1e-6, args, 50, checkiter=False)
         
     def xsolve_T_at_SP(self, phase_mol, S, T_guess, P):


### PR DESCRIPTION
- fix function calls to legacy `solve_T` (now `solve_T_at_HP` and `solve_T_at_SP`)
- add test for `Stream.mixture.solve_T_at_HP` and `Stream.mixture.solve_T_at_SP`