### PR TITLE
emphasize type of heat capacity in docstrings: isobaric

### DIFF
--- a/thermosteam/_stream.py
+++ b/thermosteam/_stream.py
@@ -1129,7 +1129,7 @@ class Stream:
     
     @property
     def C(self):
-        """[float] Heat capacity flow rate in kJ/hr."""
+        """[float] Isobaric heat capacity flow rate in kJ/hr."""
         C = self._get_property_cache('C', True)
         if C is None:
             self._property_cache['C'] = C = self.mixture.Cn(self.phase, self.mol, self.T)
@@ -1190,7 +1190,7 @@ class Stream:
         return kappa
     @property
     def Cn(self):
-        """[float] Molar heat capacity [J/mol/K]."""
+        """[float] Molar isobaric heat capacity [J/mol/K]."""
         Cn = self._get_property_cache('Cn')
         if Cn is None:
             self._property_cache['Cn'] = Cn = self.mixture.Cn(
@@ -1230,7 +1230,7 @@ class Stream:
         return epsilon
     @property
     def Cp(self):
-        """[float] Heat capacity [J/g/K]."""
+        """[float] Isobaric heat capacity [J/g/K]."""
         return self.Cn / self.MW
     @property
     def alpha(self):

--- a/thermosteam/mixture/mixture.py
+++ b/thermosteam/mixture/mixture.py
@@ -89,7 +89,7 @@ class Mixture:
     rule : str
         Description of mixing rules used.
     Cn : function(phase, mol, T)
-        Molar heat capacity mixture model [J/mol/K].
+        Molar isobaric heat capacity mixture model [J/mol/K].
     H : function(phase, mol, T)
         Enthalpy mixture model [J/mol].
     S : function(phase, mol, T, P)
@@ -135,7 +135,7 @@ class Mixture:
         Whether to include excess energies
         in enthalpy and entropy calculations.
     Cn(phase, mol, T) : 
-        Mixture molar heat capacity [J/mol/K].
+        Mixture molar isobaric heat capacity [J/mol/K].
     mu(phase, mol, T, P) : 
         Mixture dynamic viscosity [Pa*s].
     V(phase, mol, T, P) : 
@@ -257,7 +257,7 @@ class Mixture:
         return fn.V_to_rho(self.V(phase, mol, T, P), MW) if MW else 0.
     
     def Cp(self, phase, mol, T):
-        """Mixture heat capacity [J/g/K]"""
+        """Mixture isobaric heat capacity [J/g/K]"""
         MW = self.MW(mol)
         return self.Cn(phase, mol, T) / MW if MW else 0.
     
@@ -286,7 +286,7 @@ class Mixture:
         return sum([self.rho(phase, mol, T, P) for phase, mol in phase_mol])
     
     def xCp(self, phase_mol, T):
-        """Multi-phase mixture heat capacity [kg/m3]."""
+        """Multi-phase mixture isobaric heat capacity [J/g/K]."""
         return sum([self.Cp(phase, mol, T) for phase, mol in phase_mol])
     
     def xalpha(self, phase_mol, T, P):
@@ -362,7 +362,7 @@ class Mixture:
         return flx.aitken(xiter_T_at_SP, T_guess, 1e-6, args, 50, checkiter=True)
     
     def xCn(self, phase_mol, T):
-        """Multi-phase mixture heat capacity [J/mol/K]."""
+        """Multi-phase mixture molar isobaric heat capacity [J/mol/K]."""
         return sum([self.Cn(phase, mol, T) for phase, mol in phase_mol])
     
     def xH(self, phase_mol, T, P):


### PR DESCRIPTION
- document properly the type of heat capacity: isobaric (in contrast to isochoric)
- also fix a typo in documentation of `Mixture.xCp` (wrong unit)