### PR TITLE
improve solver stability close to critical point

### DIFF
--- a/thermosteam/_stream.py
+++ b/thermosteam/_stream.py
@@ -1120,6 +1120,10 @@ class Stream:
                 literal = (thermal_condition._T, thermal_condition._P)
             else:
                 phase = imol._phase._phase
+                # increase solver stability by setting phase = 'g' for T>Tc
+                Tcmax = max([c.Tc or 0 for c in self.imol.chemicals])
+                if self.T > Tcmax:
+                    phase = 'g'
                 literal = (phase, thermal_condition._T, thermal_condition._P)
             last_literal, last_composition = self._property_cache_key
             if literal == last_literal and (composition == last_composition).all():


### PR DESCRIPTION
One reason for solver instabilities is that liquid enthalpies skyrocket for T>Tc. I opened an [issue in CalebBell/thermo](https://github.com/CalebBell/thermo/issues/122) to address this. Until a more elegant solution is found, I propose to set `phase='g'` if T>Tc while getting stream properties like enthalpy, viscosity, etc. Using the proposed fix, the nitrogen liquefaction example in https://github.com/BioSTEAMDevelopmentGroup/biosteam/pull/121 works out of the box with CoolProp methods, without the need for a second convergence cycle. 

Note: I tried to put the `Tcmax` calculation into `Stream.__init__` to reduce the overhead but since there are 1283212837 other ways to create Streams in thermosteam (perceived reality 😜) and the Tcmax calculation has to be added to all of them, I could not get it to work.