### PR TITLE
Fix chemical iupac setting

### DIFF
--- a/thermosteam/_chemical.py
+++ b/thermosteam/_chemical.py
@@ -89,7 +89,7 @@ from thermo import (
 
 __all__ = ('Chemical',)
 
-# %% Temporarilly here
+# %% Temporarily here
 
 # TODO: Make a data table for new additions (not just for common sugars).
 # Source: PubChem
@@ -311,7 +311,7 @@ class Chemical:
     sigma : float or function(T), optional
         Surface tension model [N/m] as a function of temperature [K].
     epsilon : float or function(T), optional
-        Relative permitivity model [-] as a function of temperature [K].
+        Relative permittivity model [-] as a function of temperature [K].
     Psat : float or function(T), optional
         Vapor pressure model [N/m] as a function of temperature [K].
     Hvap : float or function(T), optional
@@ -475,7 +475,7 @@ class Chemical:
     sigma(T) : 
         Surface tension [N/m].
     epsilon(T) : 
-        Relative permitivity [-]
+        Relative permittivity [-]
     S(phase, T, P) : 
         Entropy [J/mol].
     H(phase, T) : 
@@ -721,7 +721,7 @@ class Chemical:
 
     @property
     def charge(self):
-        """Charge of chemical as described in the chemcial formula."""
+        """Charge of chemical as described in the chemical formula."""
         return charge_from_formula(self.formula)
 
     def copy(self, ID, CAS=None, **data):
@@ -930,7 +930,7 @@ class Chemical:
         return self._iupac_name
     @iupac_name.setter
     def iupac_name(self, iupac_name):
-        self._iupac_name = str(iupac_name)
+        self._iupac_name = str(iupac_name) if iupac_name else ()
     
     @property
     def pubchemid(self):
@@ -1067,7 +1067,7 @@ class Chemical:
         
     @property
     def epsilon(self): 
-        """Relative permitivity [-]."""
+        """Relative permittivity [-]."""
         return self._epsilon
     @epsilon.setter
     def epsilon(self, value):
@@ -1192,7 +1192,7 @@ class Chemical:
     
     @property
     def omega(self):
-        """Accentric factor [-]."""
+        """Acentric factor [-]."""
         return self._omega
     @omega.setter
     def omega(self, omega):
@@ -1462,7 +1462,7 @@ class Chemical:
         self._phase_ref = phase_ref
 
     def reset_combustion_data(self, method="Stoichiometry"):
-        """Reset combustion data (LHV, HHV, and combution attributes)
+        """Reset combustion data (LHV, HHV, and combustion attributes)
         based on the molecular formula and the heat of formation."""
         cd = combustion_data(self.atoms, Hf=self._Hf, MW=self._MW, method=method)
         if not self._MW: self._MW = cd.MW

--- a/thermosteam/_chemicals.py
+++ b/thermosteam/_chemicals.py
@@ -48,7 +48,7 @@ class Chemicals:
            * SMILES (prefix with 'SMILES=' to ensure smiles parsing)
            * CAS number
     cache : bool, optional
-        Wheather or not to use cached chemicals.
+        Whether or not to use cached chemicals.
     
     Examples
     --------
@@ -390,7 +390,7 @@ class CompiledChemicals(Chemicals):
         >>> chemicals.get_index(('Water', 'Alcohol'))
         [0, [1, 2]]
         
-        By defining a chemical group, you can conviniently use indexers
+        By defining a chemical group, you can conveniently use indexers
         to retrieve the total value of the group:
             
         >>> # Single phase stream case
@@ -560,7 +560,8 @@ class CompiledChemicals(Chemicals):
         isa = isinstance
         for i in chemicals:
             if not i.iupac_name: i.iupac_name = ()
-            elif isa(i.iupac_name, str): i.iupac_name = (i.iupac_name,)
+            elif isa(i.iupac_name, str):
+                i.iupac_name = (i.iupac_name,)
             all_names = set([*i.iupac_name, *i.aliases, i.common_name, i.formula])
             all_names_list.append(all_names)
             for name in all_names:
@@ -739,7 +740,7 @@ class CompiledChemicals(Chemicals):
     
     def ones(self):
         """
-        Return an array of ones with entries that correspond to the orded chemical IDs.
+        Return an array of ones with entries that correspond to the ordered chemical IDs.
         
         Examples
         --------
@@ -753,7 +754,7 @@ class CompiledChemicals(Chemicals):
     
     def kwarray(self, ID_data):
         """
-        Return an array with entries that correspond to the orded chemical IDs.
+        Return an array with entries that correspond to the ordered chemical IDs.
         
         Parameters
         ----------
@@ -970,7 +971,7 @@ class CompiledChemicals(Chemicals):
         Parameters
         ----------
         IDs : iterable
-              Chemical indentifiers.
+              Chemical identifiers.
 
         Examples
         --------


### PR DESCRIPTION
Hi @yoelcortes , the recent commit 4312066d9b4862bf4385f82a5187af2a4e1cb596 broke things for customized chemicals without a default `iupac_name`, where the `iupac_name` setter converts all the values to a str regardless (even if it's an empty tuple)
https://github.com/BioSTEAMDevelopmentGroup/thermosteam/blob/e3d4bcda09ebeb4796065595276b42fd32c8b3ac/thermosteam/_chemical.py#L932

but when compiling chemicals, `iupac_name` is set to a tuple, so the next time `iupac_name` is called, it becomes `('()',)`, and this creates problems downstream (apparently led to infinite loop somewhere in [qsdsan's systems](https://github.com/QSD-Group/QSDsan/actions/runs/3317172836/jobs/5480313831), [code 137](https://stackoverflow.com/questions/68844666/github-action-is-being-killed) means github killed it as it was taking huge memory)

not exactly sure how you wanted to fix it, but I changed the `iupac_name` setter from
```python self._iupac_name = str(iupac_name) ```
to 
```python self._iupac_name = str(iupac_name) if iupac_name else () ```

and it works.

the rest changes are just typo-fixing as I noticed them, thanks!