### PR TITLE
More consistensy between reaction math

### DIFF
--- a/tests/test_reaction.py
+++ b/tests/test_reaction.py
@@ -27,6 +27,14 @@ def test_reaction():
     same_reaction = reaction.copy()
     reaction += same_reaction
     reaction -= same_reaction
+    reaction += 0 # Working with 0 allows for pythonic sum method
+    reaction -= 0
+    reaction += None # While this might not make much pythonic sense, it was voted by biosteam users for convinience
+    reaction -= None
+    reaction = reaction + 0 
+    reaction = reaction - 0
+    reaction = reaction + None 
+    reaction = reaction - None
     assert_allclose(reaction.X, same_reaction.X)
     reaction *= 2.
     reaction /= 2.

--- a/thermosteam/reaction/_reaction.py
+++ b/thermosteam/reaction/_reaction.py
@@ -261,6 +261,7 @@ class Reaction:
                 if check_atomic_balance:
                     self.check_atomic_balance()
         else:
+            self._phases = ()
             self._stoichiometry = np.zeros(chemicals.size)
             self._X_index = self._chemicals.index(reactant)
     

--- a/thermosteam/reaction/_reaction.py
+++ b/thermosteam/reaction/_reaction.py
@@ -325,18 +325,18 @@ class Reaction:
         return self + rxn
     
     def __add__(self, rxn):
-        if rxn == 0 or rxn == None or not rxn.has_reaction(): return self.copy()
+        if rxn == 0 or rxn is None or not rxn.has_reaction(): return self.copy()
         rxn = self._math_compatible_reaction(rxn)
-        stoichiometry = self._stoichiometry*self.X + rxn._stoichiometry*rxn.X
-        rxn._stoichiometry = stoichiometry/-(stoichiometry[rxn._X_index])
+        stoichiometry = self._stoichiometry * self.X + rxn._stoichiometry * rxn.X
+        rxn._stoichiometry = stoichiometry / -(stoichiometry[rxn._X_index])
         rxn.X = self.X + rxn.X
         return rxn
     
     def __iadd__(self, rxn):
         if not rxn.has_reaction(): return self
         rxn = self._math_compatible_reaction(rxn, copy=False)
-        stoichiometry = self._stoichiometry*self.X + rxn._stoichiometry*rxn.X
-        self._stoichiometry = stoichiometry/-(stoichiometry[self._X_index])
+        stoichiometry = self._stoichiometry * self.X + rxn._stoichiometry * rxn.X
+        self._stoichiometry = stoichiometry / -(stoichiometry[self._X_index])
         self.X = self.X + rxn.X
         return self
     

--- a/thermosteam/reaction/_reaction.py
+++ b/thermosteam/reaction/_reaction.py
@@ -333,7 +333,7 @@ class Reaction:
         return rxn
     
     def __iadd__(self, rxn):
-        if not rxn.has_reaction(): return self
+        if rxn == 0 or rxn is None or not rxn.has_reaction(): return self
         rxn = self._math_compatible_reaction(rxn, copy=False)
         stoichiometry = self._stoichiometry * self.X + rxn._stoichiometry * rxn.X
         self._stoichiometry = stoichiometry / -(stoichiometry[self._X_index])
@@ -364,7 +364,7 @@ class Reaction:
         return new
     
     def __sub__(self, rxn):
-        if not rxn.has_reaction(): return self
+        if rxn == 0 or rxn is None or not rxn.has_reaction(): return self
         rxn = self._math_compatible_reaction(rxn)
         stoichiometry = self._stoichiometry*self.X - rxn._stoichiometry*rxn.X
         rxn._stoichiometry = stoichiometry/-(stoichiometry[rxn._X_index])
@@ -372,7 +372,7 @@ class Reaction:
         return rxn
     
     def __isub__(self, rxn):
-        if not rxn.has_reaction(): return self
+        if rxn == 0 or rxn is None or not rxn.has_reaction(): return self
         rxn = self._math_compatible_reaction(rxn, copy=False)
         stoichiometry = self._stoichiometry*self.X + rxn._stoichiometry*rxn.X
         self._stoichiometry = stoichiometry/-(stoichiometry[self._X_index])


### PR DESCRIPTION
This pull gives a bit more consistency between add and subtract methods in Reaction objects so that they work with zeros and None values. The following now works:

```python
import thermosteam as tmo
tmo.settings.set_thermo(['H2O', 'H2', 'O2'], cache=True)
reaction = tmo.Reaction('2H2O -> 2H2 + O2', reactant='H2O', X=0.4)

# add
new_reaction = (reaction + None) # This was already added by a recent commit
assert new_reaction.X == reaction.X
new_reaction = (reaction + 0)
assert new_reaction.X == reaction.X

# sub
new_reaction = (reaction - None) 
assert new_reaction.X == reaction.X
new_reaction = (reaction - 0)
assert new_reaction.X == reaction.X

# iadd
reaction += 0
assert new_reaction.X == reaction.X
reaction += None
assert new_reaction.X == reaction.X

# isub
reaction -= 0
assert new_reaction.X == reaction.X
reaction -= None
assert new_reaction.X == reaction.X
```

Thanks!