### PR TITLE
Chemical cache decorator

### DIFF
--- a/tests/test_chemicals.py
+++ b/tests/test_chemicals.py
@@ -17,4 +17,23 @@ def test_aliases():
     chemicals.define_group('alcohols', ['Water', 'Ethanol'])
     assert set(chemicals.get_aliases('H2O')) == set(['7732-18-5', 'Water', 'water', 'oxidane', 'H2O'])
     
+def test_chemical_cache():
     
+    @tmo.utils.chemical_cache
+    def create_ethanol_chemicals(other_chemicals):
+        chemicals = tmo.Chemicals(['Water', 'Ethanol', *other_chemicals])
+        return chemicals
+    
+    chemicals_a = create_ethanol_chemicals(('CO2', 'O2'))
+    chemicals_b = create_ethanol_chemicals(('CO2', 'O2'))
+    assert chemicals_a is chemicals_b
+    
+    chemicals_c = create_ethanol_chemicals(('O2',))
+    assert chemicals_a is not chemicals_c 
+    assert chemicals_a.Water is chemicals_c.Water
+    assert chemicals_b.CO2 is not chemicals_c.O2
+    
+    
+if __name__ == '__main__':
+    test_aliases()
+    test_chemical_cache()

--- a/tests/test_chemicals.py
+++ b/tests/test_chemicals.py
@@ -31,7 +31,7 @@ def test_chemical_cache():
     chemicals_c = create_ethanol_chemicals(('O2',))
     assert chemicals_a is not chemicals_c 
     assert chemicals_a.Water is chemicals_c.Water
-    assert chemicals_b.CO2 is not chemicals_c.O2
+    assert chemicals_b.O2 is chemicals_c.O2
     
     
 if __name__ == '__main__':

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -20,6 +20,12 @@ def test_registration_bypass():
     assert s.ID == 's.1'
     assert s not in s.registry
 
+def test_registration_alias():
+    tmo.settings.set_thermo(['Water'], cache=True)
+    s = tmo.Stream('s1', Water=1)
+    s.register_alias('stream_1')
+    assert s.registry.stream_1 is s.registry.s1 is s
+
 def test_vlle():
     tmo.settings.set_thermo(['Water', 'Ethanol', 'Octane'], cache=True)
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, vlle=True, T=350)
@@ -349,6 +355,7 @@ def test_vle_critical_pure_component():
     
 if __name__ == '__main__':
     test_registration_bypass()
+    test_registration_alias()
     test_stream()
     test_multistream()
     test_mixing_balance()

--- a/thermosteam/_chemical.py
+++ b/thermosteam/_chemical.py
@@ -558,7 +558,7 @@ class Chemical:
         if default: self.default()
         if cache:
             chemical_cache[ID] = self
-            if len(chemical_cache) > 100:
+            if len(chemical_cache) > 1000:
                 for i in chemical_cache:
                     del chemical_cache[i]
                     break

--- a/thermosteam/_chemical.py
+++ b/thermosteam/_chemical.py
@@ -514,7 +514,8 @@ class Chemical:
                 sigma=None, kappa=None, epsilon=None, Psat=None,
                 Hvap=None, method=None, **data):
         chemical_cache = cls.chemical_cache
-        if (cache or cls.cache) and ID in chemical_cache:
+        if cache is None: cache = cls.cache
+        if cache and ID in chemical_cache:
             if any([search_ID, eos, phase_ref, CAS, default, phase, 
                     V, Cn, mu, Cp, rho, sigma, kappa, epsilon, Psat, Hvap,
                     data]):

--- a/thermosteam/_chemicals.py
+++ b/thermosteam/_chemicals.py
@@ -115,7 +115,7 @@ class Chemicals:
     UndefinedChemicalAlias: 'Butane'
     
     """
-    def __new__(cls, chemicals, cache=False):
+    def __new__(cls, chemicals, cache=None):
         self = super().__new__(cls)
         isa = isinstance
         setfield = setattr

--- a/thermosteam/functional.py
+++ b/thermosteam/functional.py
@@ -8,6 +8,7 @@
 """
 """
 from chemicals import *
+from chemicals.utils import *
 from fluids.core import Pr, alpha
 from numba import njit
 from thermosteam.base import functor

--- a/thermosteam/reaction/_reaction.py
+++ b/thermosteam/reaction/_reaction.py
@@ -433,12 +433,13 @@ class Reaction:
             MW_reactant = chemicals_tuple[reactant_index].MW
             MW_product = chemicals_tuple[product_index].MW
             if basis == 'wt':
-                product_yield *= MW_reactant / MW_product
+                product_yield *= MW_product / MW_reactant 
             elif basis == 'mol':
-                product_yield *= MW_product / MW_reactant
+                product_yield *= MW_reactant / MW_product 
             else:
                 raise ValueError("basis must be either 'wt' or 'mol'; "
                                 f"not {repr(basis)}")
+        assert product_yield <= 1.
         return product_yield
     
     def adiabatic_reaction(self, stream):

--- a/thermosteam/reaction/_reaction.py
+++ b/thermosteam/reaction/_reaction.py
@@ -1448,6 +1448,9 @@ class ReactionSystem:
     __call__ = Reaction.__call__
     show = Reaction.show
     
+    def __iter__(self):
+        return iter(self.reactions)
+    
     def __getitem__(self, index):
         return self._reactions[index]
     

--- a/thermosteam/utils/decorators/__init__.py
+++ b/thermosteam/utils/decorators/__init__.py
@@ -13,13 +13,15 @@ from . import read_only
 from . import registered
 from . import forward
 from . import units_of_measure
+from . import chemical_cache
 
 __all__ = (*chemicals_user.__all__,
            *thermo_user.__all__,
            *read_only.__all__,
            *registered.__all__,
            *forward.__all__,
-           *units_of_measure.__all__)
+           *units_of_measure.__all__,
+           *chemical_cache.__all__)
 
 from .registered import *
 from .chemicals_user import *
@@ -27,3 +29,4 @@ from .thermo_user import *
 from .read_only import *
 from .forward import *
 from .units_of_measure import *
+from .chemical_cache import *

--- a/thermosteam/utils/decorators/chemical_cache.py
+++ b/thermosteam/utils/decorators/chemical_cache.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Dec 17 17:15:23 2022
+
+@author: yrc2
+"""
+import thermosteam as tmo
+from functools import cache
+
+__all__ = ('chemical_cache',)
+
+def chemical_cache(f):
+    g = cache(f)
+    def h(*args, cache=True, **kwargs):
+        if cache:
+            Chemical = tmo.Chemical
+            caching = Chemical.cache
+            Chemical.cache = True
+            value = g(*args, **kwargs)
+            Chemical.cache = caching
+        else:
+            value = f(*args, **kwargs)
+        return value
+    h.__name__ = f.__name__
+    return h


### PR DESCRIPTION
This is a simple enhancement, so I am requesting newer members for their review :)

The pull request adds a new `chemical_cache` decorator that acts like [functools.cache](https://docs.python.org/3/library/functools.html) but with the added feature that it avoids recreating Chemical objects.

This pull request also fixes a bug so that when the default Chemical.cache is True, chemicals are cached (unless `Chemical(..., cache=False)`).

Here is the example which was added to the tests:

```python
@tmo.utils.chemical_cache
def create_ethanol_chemicals(other_chemicals):
    chemicals = tmo.Chemicals(['Water', 'Ethanol', *other_chemicals])
    return chemicals

chemicals_a = create_ethanol_chemicals(('CO2', 'O2'))
chemicals_b = create_ethanol_chemicals(('CO2', 'O2'))
assert chemicals_a is chemicals_b

chemicals_c = create_ethanol_chemicals(('O2',))
assert chemicals_a is not chemicals_c 
assert chemicals_a.Water is chemicals_c.Water
assert chemicals_b.O2 is chemicals_c.O2
```