### PR TITLE
Add parameter for sorting flows in stream show method

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -39,7 +39,7 @@ def test_vlle():
     xg = s.imol['g'].sum() / total
     assert_allclose(xl, 0.14900116395733892, rtol=0.1)
     assert_allclose(xL, 0.5145493042005613, rtol=0.1) # Convergence
-    assert_allclose(xg, 0.33644953184209986)
+    assert_allclose(xg, 0.33644953184209986, rtol=0.1)
     # Make sure past equilibrium conditions do not affect result of vlle
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, T=350)
     s.vle(T=350, P=101325)
@@ -50,7 +50,7 @@ def test_vlle():
     xg = s.imol['g'].sum() / total
     assert_allclose(xl, 0.14900116395733892, rtol=0.1)
     assert_allclose(xL, 0.5145493042005613, rtol=0.1) # Convergence
-    assert_allclose(xg, 0.33644953184209986)
+    assert_allclose(xg, 0.33644953184209986, rtol=0.1)
     
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, vlle=True, T=300)
     assert set(s.phases) == set(['l', 'L']) # No gas phase

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -33,16 +33,24 @@ def test_vlle():
     tmo.settings.set_thermo(['Water', 'Ethanol', 'Octane'], cache=True)
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, vlle=True, T=350)
     assert_allclose(s.mol, [1, 1, 2]) # mass balance
-    assert_allclose(s.imol['l'] + s.imol['L'], [0.5298055753954918, 0.37320491618563845, 1.7511913810504698], rtol=0.1)
-    assert_allclose(s.imol['g'], [0.47019442460450805, 0.6267950838143611, 0.24880861894952971], rtol=0.1) # Convergence
-    
+    total = s.F_mol
+    xl = s.imol['l'].sum() / total
+    xL = s.imol['L'].sum() / total
+    xg = s.imol['g'].sum() / total
+    assert_allclose(xl, 0.14900116395733892, rtol=0.1)
+    assert_allclose(xL, 0.5145493042005613, rtol=0.1) # Convergence
+    assert_allclose(xg, 0.33644953184209986)
     # Make sure past equilibrium conditions do not affect result of vlle
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, T=350)
     s.vle(T=350, P=101325)
     s.vlle(T=350, P=101325)
     assert_allclose(s.mol, [1, 1, 2]) # mass balance
-    assert_allclose(s.imol['l'] + s.imol['L'], [0.5298055753954918, 0.37320491618563845, 1.7511913810504698], rtol=0.1)
-    assert_allclose(s.imol['g'], [0.47019442460450805, 0.6267950838143611, 0.24880861894952971], rtol=0.1) # Convergence
+    xl = s.imol['l'].sum() / total
+    xL = s.imol['L'].sum() / total
+    xg = s.imol['g'].sum() / total
+    assert_allclose(xl, 0.14900116395733892, rtol=0.1)
+    assert_allclose(xL, 0.5145493042005613, rtol=0.1) # Convergence
+    assert_allclose(xg, 0.33644953184209986)
     
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, vlle=True, T=300)
     assert set(s.phases) == set(['l', 'L']) # No gas phase

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -33,8 +33,17 @@ def test_vlle():
     tmo.settings.set_thermo(['Water', 'Ethanol', 'Octane'], cache=True)
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, vlle=True, T=350)
     assert_allclose(s.mol, [1, 1, 2]) # mass balance
-    assert_allclose(s.imol['l'] + s.imol['L'], [0.537583, 0.383255, 1.755296], rtol=0.1)
+    assert_allclose(s.imol['l'] + s.imol['L'], [0.5298055753954918, 0.37320491618563845, 1.7511913810504698], rtol=0.1)
     assert_allclose(s.imol['g'], [0.47019442460450805, 0.6267950838143611, 0.24880861894952971], rtol=0.1) # Convergence
+    
+    # Make sure past equilibrium conditions do not affect result of vlle
+    s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, T=350)
+    s.vle(T=350, P=101325)
+    s.vlle(T=350, P=101325)
+    assert_allclose(s.mol, [1, 1, 2]) # mass balance
+    assert_allclose(s.imol['l'] + s.imol['L'], [0.5298055753954918, 0.37320491618563845, 1.7511913810504698], rtol=0.1)
+    assert_allclose(s.imol['g'], [0.47019442460450805, 0.6267950838143611, 0.24880861894952971], rtol=0.1) # Convergence
+    
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, vlle=True, T=300)
     assert set(s.phases) == set(['l', 'L']) # No gas phase
     assert_allclose(s.mol, [1, 1, 2]) # mass balance
@@ -354,7 +363,6 @@ def test_vle_critical_pure_component():
     assert s.phase == 'g'
     s.vle(P=N2.Pc, S=s.S + 10)
     assert s.phase == 'g'
-    
     
 if __name__ == '__main__':
     test_registration_bypass()

--- a/thermosteam/_stream.py
+++ b/thermosteam/_stream.py
@@ -2657,6 +2657,22 @@ class Stream:
         df :
             Whether to return a pandas DataFrame.
         
+        Examples
+        --------
+        Show a stream's composition by weight for only the top 2 chemicals
+        with the highest mass fractions:
+            
+        >>> import biosteam as bst
+        >>> bst.settings.set_thermo(['Water', 'Ethanol', 'Methanol', 'Propanol'])
+        >>> stream = bst.Stream('stream', Water=0.5, Ethanol=1.5, Methanol=0.2, Propanol=0.3, units='kg/hr')
+        >>> stream.show('cwt2s') # Alternatively: stream.show(composition=True, flow='kg/hr', N=2, sort=True)
+        Stream: stream
+         phase: 'l', T: 298.15 K, P: 101325 Pa
+         composition (%): Ethanol  60
+                          Water    20
+                          ...      20
+                          -------  2.5 kg/hr
+        
         """
         print(self._info(layout, T, P, flow, composition, N, IDs, sort, df))
     _ipython_display_ = show


### PR DESCRIPTION
@sarangbhagwat, @yalinli2 

This pull adds a `sort` parameter for sorting flows (in decreasing order) in the `Stream.show` method. A doctest to test this is also added:

```python
Examples
--------
Show a stream's composition by weight for only the top 2 chemicals
with the highest mass fractions:
    
>>> import biosteam as bst
>>> bst.settings.set_thermo(['Water', 'Ethanol', 'Methanol', 'Propanol'])
>>> stream = bst.Stream('stream', Water=0.5, Ethanol=1.5, Methanol=0.2, Propanol=0.3, units='kg/hr')
>>> stream.show('cwt2s') # Alternatively: stream.show(composition=True, flow='kg/hr', N=2, sort=True)
Stream: stream
 phase: 'l', T: 298.15 K, P: 101325 Pa
 composition (%): Ethanol  60
                  Water    20
                  ...      20
                  -------  2.5 kg/hr
```

This pull also adds a minor enhancement to Stream.vlle for consistent results (results are now the same regardless if stream starts as a gas or a liquid).

Once this pull is merged, I'll make another pull request in BioSTEAM for using the new `sort` parameter in `Unit.show` and `System.show`.

Thanks!