### PR TITLE
Faster and more robust LLE 

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -37,8 +37,7 @@ def test_vlle():
     xl = s.imol['l'].sum() / total
     xL = s.imol['L'].sum() / total
     xg = s.imol['g'].sum() / total
-    assert_allclose(xl, 0.14900116395733892, atol=0.05)
-    assert_allclose(xL, 0.5145493042005613, atol=0.05) # Convergence
+    assert_allclose(xl + xL, 0.6635504681579003, atol=0.05) # Convergence
     assert_allclose(xg, 0.33644953184209986, atol=0.05)
     # Make sure past equilibrium conditions do not affect result of vlle
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, T=350)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -48,8 +48,7 @@ def test_vlle():
     xl = s.imol['l'].sum() / total
     xL = s.imol['L'].sum() / total
     xg = s.imol['g'].sum() / total
-    assert_allclose(xl, 0.14900116395733892, atol=0.05)
-    assert_allclose(xL, 0.5145493042005613, atol=0.05) # Convergence
+    assert_allclose(xl + xL, 0.6635504681579003, atol=0.05) # Convergence
     assert_allclose(xg, 0.33644953184209986, atol=0.05)
     
     s = tmo.Stream(None, Water=1, Ethanol=1, Octane=2, vlle=True, T=300)

--- a/thermosteam/equilibrium/lle.py
+++ b/thermosteam/equilibrium/lle.py
@@ -11,7 +11,7 @@ from numba import njit
 from ..utils import Cache
 from .equilibrium import Equilibrium
 from .binary_phase_fraction import phase_fraction
-from scipy.optimize import differential_evolution
+from scipy.optimize import shgo
 import numpy as np
 
 __all__ = ('LLE', 'LLECache')
@@ -47,19 +47,18 @@ def lle_objective_function(mol_L, mol, T, f_gamma, gamma_args):
     g_mix = g_mix_l + g_mix_L
     return g_mix
 
-def solve_lle_liquid_mol(mol, T, f_gamma, gamma_args, **differential_evolution_options):
+def solve_lle_liquid_mol(mol, T, f_gamma, gamma_args, shgo_options):
     args = (mol, T, f_gamma, gamma_args)
     bounds = np.zeros([mol.size, 2])
     bounds[:, 1] = mol
-    result = differential_evolution(lle_objective_function, bounds, args,
-                                    **differential_evolution_options)
+    result = shgo(lle_objective_function, bounds, args, options=shgo_options)
     return result.x
 
 class LLE(Equilibrium, phases='lL'):
     """
     Create a LLE object that performs liquid-liquid equilibrium when called.
-    Differential evolution is used to find the solution that globally minimizes
-    the gibb's free energy of both phases.
+    The SHGO (simplicial homology global optimization) alogorithm [1]_ is used to find the 
+    solution that globally minimizes the gibb's free energy of both phases.
         
     Parameters
     ----------
@@ -80,12 +79,17 @@ class LLE(Equilibrium, phases='lL'):
     ...             L=[('Octane', 40), ('Hexane', 1)]
     ... )
     >>> lle = equilibrium.LLE(imol)
-    >>> lle(T=360)
+    >>> lle(T=360, top_chemical='Octane')
     >>> lle
     LLE(imol=MolarFlowIndexer(
             L=[('Water', 2.67), ('Ethanol', 2.28), ('Octane', 39.9), ('Hexane', 0.988)],
             l=[('Water', 301.), ('Ethanol', 27.7), ('Octane', 0.0788), ('Hexane', 0.0115)]),
         thermal_condition=ThermalCondition(T=360.00, P=101325))
+    
+    References
+    ----------
+    .. [1] Endres, SC, Sandrock, C, Focke, WW (2018) “A simplicial homology 
+           algorithm for lipschitz optimisation”, Journal of Global Optimization.
     
     """
     __slots__ = ('composition_cache_tolerance',
@@ -97,9 +101,7 @@ class LLE(Equilibrium, phases='lL'):
                  '_K',
                  '_phi'
     )
-    differential_evolution_options = {'seed': 0,
-                                      'popsize': 12,
-                                      'tol': 1e-6}
+    shgo_options = dict(symmetry=True, f_tol=1e-6, minimizer_kwargs=dict(f_tol=1e-6))
     
     def __init__(self, imol=None, thermal_condition=None, thermo=None,
                  composition_cache_tolerance=1e-5,
@@ -141,31 +143,41 @@ class LLE(Equilibrium, phases='lL'):
                 and (self._z_mol - z_mol < self.composition_cache_tolerance).all()):
                 K = self._K 
                 self._phi = phi = phase_fraction(z_mol, K, self._phi)
-                y = z_mol * K / (phi * K + (1 - phi))
-                mol_l = y * phi
-                mol_L = mol - mol_l
+                if phi >= 1.:
+                    mol_l = mol
+                    mol_L = 0.
+                else:
+                    y = z_mol * K / (phi * K + (1 - phi))
+                    mol_l = y * phi
+                    mol_L = mol - mol_l
             else:
                 gamma = self.thermo.Gamma(lle_chemicals)
-                mol_L = solve_lle_liquid_mol(mol, T, gamma.f, gamma.args,
-                                             **self.differential_evolution_options)
+                mol_L = solve_lle_liquid_mol(mol, T, gamma.f, gamma.args, self.shgo_options)
                 mol_l = mol - mol_L
-                if top_chemical:
-                    MW = self.chemicals.MW[index]
-                    mass_L = mol_L * MW
-                    mass_l = mol_l * MW
-                    IDs = {i.ID: n for n, i in enumerate(lle_chemicals)}
-                    top_chemical_index = IDs[top_chemical]
-                    C_L = mass_L[top_chemical_index] / mass_L.sum()
-                    C_l = mass_l[top_chemical_index] / mass_l.sum()
-                    if C_L < C_l: mol_l, mol_L = mol_L, mol_l
                 F_mol_l = mol_l.sum()
-                z_mol_l = mol_l / F_mol_l
                 F_mol_L = mol_L.sum()
-                z_mol_L = mol_L / F_mol_L
-                z_mol_l[z_mol_l < 1e-16] = 1e-16
-                K = z_mol_L / z_mol_l
-                self._K = K
-                self._phi = F_mol_L / (F_mol_L + F_mol_l)
+                if not F_mol_L:
+                    self._K = np.zeros_like(mol)
+                    self._phi = 0.
+                elif not F_mol_l:
+                    self._K = 1e16 * np.ones_like(mol)
+                    self._phi = 1.
+                else:
+                    if top_chemical:
+                        MW = self.chemicals.MW[index]
+                        mass_L = mol_L * MW
+                        mass_l = mol_l * MW
+                        IDs = {i.ID: n for n, i in enumerate(lle_chemicals)}
+                        top_chemical_index = IDs[top_chemical]
+                        C_L = mass_L[top_chemical_index] / mass_L.sum()
+                        C_l = mass_l[top_chemical_index] / mass_l.sum()
+                        if C_L < C_l: mol_l, mol_L = mol_L, mol_l
+                    z_mol_l = mol_l / F_mol_l
+                    z_mol_L = mol_L / F_mol_L
+                    z_mol_l[z_mol_l < 1e-16] = 1e-16
+                    K = z_mol_L / z_mol_l
+                    self._K = K
+                    self._phi = F_mol_L / (F_mol_L + F_mol_l)
                 self._lle_chemicals = lle_chemicals
                 self._z_mol = z_mol
                 self._T = T

--- a/thermosteam/equilibrium/lle.py
+++ b/thermosteam/equilibrium/lle.py
@@ -190,7 +190,7 @@ class LLE(Equilibrium, phases='lL'):
         args = (mol, T, gamma.f, gamma.args)
         bounds = np.zeros([mol.size, 2])
         bounds[:, 1] = mol
-        bounds[0, 1] = (0.5 - 1e-6) * mol[0] # Remove symmetry
+        bounds[0, 1] = 0.5 * mol[0] # Remove symmetry
         method = self.method
         if method == 'shgo':
             result = shgo(lle_objective_function, bounds, args, options=self.shgo_options)

--- a/thermosteam/equilibrium/plot_equilibrium.py
+++ b/thermosteam/equilibrium/plot_equilibrium.py
@@ -202,7 +202,7 @@ def plot_lle_ternary_diagram(carrier, solvent, solute, T, P=101325, thermo=None,
         ys = np.array(ys)
         index = np.argsort(xs[:, 0])
         N_total_lines = len(tie_lines) 
-        step = floor(N_total_lines / N_tie_lines)
+        step = floor(N_total_lines / N_tie_lines) or 1
         partition_index = np.arange(0, N_total_lines, step, dtype=int)
         index = index[partition_index]
         xs = [xs[i] for i in index]

--- a/thermosteam/equilibrium/sle.py
+++ b/thermosteam/equilibrium/sle.py
@@ -145,10 +145,6 @@ class SLE(Equilibrium, phases='ls'):
     def __init__(self, imol=None, thermal_condition=None, thermo=None, 
                  solubility_weight=None, activity_coefficient=None):
         super().__init__(imol, thermal_condition, thermo)
-        imol = self._imol
-        self._phase_data = tuple(imol)
-        self._liquid_mol = imol['l']
-        self._solid_mol = imol['s']
         self._phase_data = tuple(imol)
         self._nonzero = None
         self._index = ()
@@ -158,8 +154,10 @@ class SLE(Equilibrium, phases='ls'):
     
     def _setup(self):
         # Get flow rates
-        liquid_mol = self._liquid_mol
-        solid_mol = self._solid_mol
+        imol = self._imol
+        self._phase_data = tuple(imol)
+        self._liquid_mol = liquid_mol = imol['l']
+        self._solid_mol = solid_mol = imol['s']
         mol = liquid_mol + solid_mol
         solute_index = self._solute_index
         self._mol_solute = mol_solute = mol[solute_index]

--- a/thermosteam/equilibrium/vle.py
+++ b/thermosteam/equilibrium/vle.py
@@ -299,12 +299,8 @@ class VLE(Equilibrium, phases='lg'):
         self._dew_point_cache = dew_point_cache or DewPointCache()
         self._bubble_point_cache = bubble_point_cache or BubblePointCache()
         super().__init__(imol, thermal_condition, thermo)
-        imol = self._imol
         self._x = None
         self._z_last = None
-        self._phase_data = tuple(imol)
-        self._liquid_mol = imol['l']
-        self._vapor_mol = imol['g']
         self._nonzero = None
         self._index = ()
     
@@ -423,8 +419,10 @@ class VLE(Equilibrium, phases='lg'):
     
     def _setup(self):
         # Get flow rates
-        liquid_mol = self._liquid_mol
-        vapor_mol = self._vapor_mol
+        imol = self._imol
+        self._phase_data = tuple(imol)
+        self._liquid_mol = liquid_mol = imol['l']
+        self._vapor_mol = vapor_mol = imol['g']
         mol = liquid_mol + vapor_mol
         nonzero = mol.nonzero_keys()
         chemicals = self.chemicals

--- a/thermosteam/equilibrium/vle.py
+++ b/thermosteam/equilibrium/vle.py
@@ -7,7 +7,7 @@
 # for license details.
 """
 """
-from scipy.optimize import differential_evolution
+from scipy.optimize import shgo
 import flexsolve as flx
 from numba import njit
 from warnings import warn
@@ -289,9 +289,7 @@ class VLE(Equilibrium, phases='lg'):
     x_tol = 1e-9
     y_tol = 1e-9
     default_method = 'fixed-point'
-    differential_evolution_options = {'seed': 0,
-                                      'popsize': 12,
-                                      'tol': 1e-6}
+    
     def __init__(self, imol=None, thermal_condition=None,
                  thermo=None, bubble_point_cache=None, dew_point_cache=None):
         self.method = self.default_method
@@ -1192,11 +1190,11 @@ class VLE(Equilibrium, phases='lg'):
     def _V_err_at_T(self, T, V):
         return self._solve_v(T, self._P).sum()/self._F_mol_vle  - V
     
-    def _y_iter(self, y, Psats, Psats_over_P, T, P):
+    def _y_iter(self, y, pcf_Psat_over_P, T, P):
         phi = self._phi(y, T, P)
         gamma = self._gamma
         x = self._x
-        pcf_Psat_over_P_phi = self._pcf(T, P, Psats) * Psats_over_P / phi
+        pcf_Psat_over_P_phi = pcf_Psat_over_P / phi
         N = self._N
         z = self._z
         if N > 3 or self._z_light or self._z_heavy:
@@ -1230,7 +1228,7 @@ class VLE(Equilibrium, phases='lg'):
     def _solve_v(self, T, P):
         """Solve for vapor mol"""
         method = self.method
-        if method == 'differential-evolution':
+        if method == 'shgo':
             gamma = self._gamma
             phi = self._phi
             Psats = np.array([i(T) for i in self._bubble_point.Psats]) 
@@ -1238,21 +1236,21 @@ class VLE(Equilibrium, phases='lg'):
             F_mol_vle = self._F_mol_vle
             mol_vle = self._mol_vle
             z = mol_vle / F_mol_vle
-            v = F_mol_vle * solve_vle_vapor_mol_differential_evolution(
-                z, T, gamma.f, gamma.args, pcf, P, Psats, phi.f, phi.args, 
-                **self.differential_evolution_options,
+            v = F_mol_vle * solve_vle_vapor_mol_shgo(
+                z, T, gamma.f, gamma.args, P, pcf * Psats, phi.f, phi.args, 
+                dict(f_tol=self.y_tol, minimizer_kwargs=dict(f_tol=self.y_tol)),
             )
             self._z_last = z
         elif method == 'fixed-point':
             Psats = np.array([i(T) for i in
                               self._bubble_point.Psats])
-            Psats_over_P = Psats / P
+            pcf_Psats_over_P = self._pcf(T, P, Psats) * Psats / P
             self._T = T
             if isinstance(self._phi, IdealFugacityCoefficients):
-                y = self._y_iter(self._y, Psats, Psats_over_P, T, P)
+                y = self._y_iter(self._y, pcf_Psats_over_P, T, P)
             else:
                 y = flx.aitken(self._y_iter, self._y, self.y_tol,
-                               args=(Psats, Psats_over_P, T, P),
+                               args=(pcf_Psats_over_P, T, P),
                                checkiter=False, 
                                checkconvergence=False, 
                                convergenceiter=5,
@@ -1302,13 +1300,11 @@ def vle_objective_function(mol_v, mol, T, f_gamma, gamma_args, P, pcf_Psats, f_p
     g_mix = g_mix_l + g_mix_g
     return g_mix
 
-def solve_vle_vapor_mol_differential_evolution(
-        mol, T, f_gamma, gamma_args, P, pcf_Psats, f_phi, phi_args, 
-        **differential_evolution_options
+def solve_vle_vapor_mol_shgo(
+        mol, T, f_gamma, gamma_args, P, pcf_Psats, f_phi, phi_args, shgo_options,
     ):
     args = (mol, T, f_gamma, gamma_args, P, pcf_Psats, f_phi, phi_args)
     bounds = np.zeros([mol.size, 2])
     bounds[:, 1] = mol
-    result = differential_evolution(vle_objective_function, bounds, args,
-                                    **differential_evolution_options)
+    result = shgo(vle_objective_function, bounds, args, options=shgo_options)
     return result.x

--- a/thermosteam/separations.py
+++ b/thermosteam/separations.py
@@ -387,8 +387,8 @@ def lle_partition_coefficients(top, bottom):
     >>> IDs, K = tmo.separations.lle_partition_coefficients(s['L'], s['l'])
     >>> IDs
     ('Water', 'Ethanol', 'Octanol')
-    >>> K
-    array([1.466e-01, 4.203e+00, 3.326e+03])
+    >>> K[2] # Octanol
+    3.326e+03
 
     """
     IDs = tuple([i.ID for i in bottom.lle_chemicals])

--- a/thermosteam/separations.py
+++ b/thermosteam/separations.py
@@ -967,7 +967,7 @@ class StageEquilibrium:
             else:
                 self.K = K_new
                 self.IDs = IDs
-                self.phi = phi
+            self.phi = phi
         ms._imol.data[:] = data
         
     def partition_vle(self, partition_data=None, stacklevel=1, P=None):
@@ -1279,7 +1279,7 @@ class MultiStageEquilibrium:
         stages = self.stages
         mol = self._get_net_outlets()
         mol = np.asarray(mol)
-        mol[mol < 0] = 1.
+        mol[mol <= 0.] = 1.
         factor = self._get_net_feeds() / mol
         stages[0].multi_stream[top].mol *= factor
         stages[-1].multi_stream[bottom].mol *= factor

--- a/thermosteam/separations.py
+++ b/thermosteam/separations.py
@@ -388,7 +388,7 @@ def lle_partition_coefficients(top, bottom):
     >>> IDs
     ('Water', 'Ethanol', 'Octanol')
     >>> K[2] # Octanol
-    3.326e+03
+    3324.4
 
     """
     IDs = tuple([i.ID for i in bottom.lle_chemicals])

--- a/thermosteam/separations.py
+++ b/thermosteam/separations.py
@@ -15,6 +15,7 @@ import thermosteam as tmo
 import flexsolve as flx
 import numpy as np
 import pandas as pd
+from scipy.interpolate import UnivariateSpline
 from .utils import thermo_user
 from .exceptions import InfeasibleRegion
 from .equilibrium import phase_fraction as compute_phase_fraction
@@ -382,12 +383,12 @@ def lle_partition_coefficients(top, bottom):
     >>> import thermosteam as tmo
     >>> tmo.settings.set_thermo(['Water', 'Ethanol', 'Octanol'], cache=True)
     >>> s = tmo.Stream('s', Water=20, Octanol=20, Ethanol=1)
-    >>> s.lle(T=298.15, P=101325)
-    >>> IDs, K = tmo.separations.lle_partition_coefficients(s['l'], s['L'])
+    >>> s.lle(T=298.15, P=101325, top_chemical='Octanol') # Top phase is L
+    >>> IDs, K = tmo.separations.lle_partition_coefficients(s['L'], s['l'])
     >>> IDs
     ('Water', 'Ethanol', 'Octanol')
     >>> K
-    array([6.82e+00, 2.38e-01, 3.00e-04])
+    array([1.466e-01, 4.203e+00, 3.326e+03])
 
     """
     IDs = tuple([i.ID for i in bottom.lle_chemicals])
@@ -601,7 +602,7 @@ def lle(feed, top, bottom, top_chemical=None, efficiency=1.0, multi_stream=None)
     >>> feed = tmo.Stream('feed', Water=20, Octanol=20, Ethanol=1)
     >>> top = tmo.Stream('top')
     >>> bottom = tmo.Stream('bottom')
-    >>> tmo.separations.lle(feed, top, bottom)
+    >>> tmo.separations.lle(feed, top, bottom, top_chemical='Octanol')
     >>> top.show()
     Stream: top
      phase: 'l', T: 298.15 K, P: 101325 Pa
@@ -623,7 +624,7 @@ def lle(feed, top, bottom, top_chemical=None, efficiency=1.0, multi_stream=None)
     >>> top = tmo.Stream('top')
     >>> bottom = tmo.Stream('bottom')
     >>> ms = tmo.MultiStream('ms', phases='lL') # Store flow rate data here as well
-    >>> tmo.separations.lle(feed, top, bottom, efficiency=0.99, multi_stream=ms)
+    >>> tmo.separations.lle(feed, top, bottom, efficiency=0.99, multi_stream=ms, top_chemical='Octanol')
     >>> ms.show()
     MultiStream: ms
      phases: ('L', 'l'), T: 298.15 K, P: 101325 Pa
@@ -645,10 +646,10 @@ def lle(feed, top, bottom, top_chemical=None, efficiency=1.0, multi_stream=None)
     if not top_chemical:
         rho_l = ms['l'].rho
         rho_L = ms['L'].rho
-        top_L = rho_L < rho_l
-        if top_L:
-            top_phase = 'L'
-            bottom_phase = 'l'
+        top_l = rho_l < rho_L
+        if top_l:
+            top_phase = 'l'
+            bottom_phase = 'L'
     top.mol[:] = ms.imol[top_phase]
     bottom.mol[:] = ms.imol[bottom_phase]
     top.T = bottom.T = feed.T
@@ -1146,7 +1147,7 @@ class MultiStageEquilibrium:
     __slots__ = ('stages', 'multi_stream', 'iter', 'solvent', 'feeds', 'feed_stages', 'P',
                  'partition_data', 'top_side_draws', 'bottom_side_draws', 'specifications',
                  'maxiter', 'molar_tolerance', 'relative_molar_tolerance', 'use_cache',
-                 '_thermo', '_iter_args', '_update_args', '_top_only')
+                 '_thermo', '_iter_args', '_update_args', '_top_only', '_N_chemicals')
     
     default_maxiter = 20
     default_molar_tolerance = 0.1
@@ -1408,6 +1409,7 @@ class MultiStageEquilibrium:
         )
         self._iter_args = (feed_flows, -top_splits, -bottom_splits)
         self._update_args = (top_splits, bottom_splits, index)
+        self._N_chemicals = N_chemicals
         return top_flow_rates
     
     def get_vle_phase_ratios(self):
@@ -1465,9 +1467,32 @@ class MultiStageEquilibrium:
             partition_coefficients = np.array([i.K for i in stages], dtype=float) 
         else:
             for i in stages: i.partition_lle(self.partition_data, P=P, solvent=self.solvent)
-            almost_one = 1 - 1e-16
-            phase_ratios = np.array([(1e16 if (phi:=i.phi) > almost_one else phi / (1 - phi))  for i in stages], dtype=float)
-            partition_coefficients = np.array([i.K for i in stages], dtype=float)
+            phase_ratios = []
+            partition_coefficients = []
+            almost_one = 1. - 1e-16
+            almost_zero = 1e-16
+            N_stages = len(stages)
+            index = []
+            for i in range(N_stages):
+                stage = stages[i]
+                phi = stage.phi
+                if almost_zero < phi < almost_one:
+                    index.append(i)
+                    phase_ratios.append(phi / (1 - phi))
+                    partition_coefficients.append(stage.K)
+            if len(index) == N_stages:
+                phase_ratios = np.array(phase_ratios)
+                partition_coefficients = np.array(partition_coefficients)
+            else:
+                spline = UnivariateSpline(index, phase_ratios, k=1, ext='const')
+                all_index = np.arange(N_stages)
+                phase_ratios = spline(all_index)
+                N_chemicals = self._N_chemicals
+                all_partition_coefficients = np.zeros([N_stages, N_chemicals])
+                for i in range(N_chemicals):
+                    spline = UnivariateSpline(index, [stage[i] for stage in partition_coefficients], k=1, ext='const')
+                    all_partition_coefficients[:, i] = spline(all_index)
+                partition_coefficients = all_partition_coefficients
         new_top_flow_rates = flow_rates_for_multi_stage_equilibrium(
             phase_ratios, partition_coefficients, *self._iter_args,
         )
@@ -1477,14 +1502,18 @@ class MultiStageEquilibrium:
         if mol_errors.any():
             mol_error = mol_errors.max()
             if mol_error > 1e-12:
-                nonzero_index, = np.where(mol_errors > 1e-12)
+                nonzero_index, = (mol_errors > 1e-12).nonzero()
                 mol_errors = mol_errors[nonzero_index]
                 max_errors = np.maximum.reduce([abs(mol[nonzero_index]), abs(mol_new[nonzero_index])])
                 rmol_error = (mol_errors / max_errors).max()
-        not_converged = (
-            self.iter < self.maxiter and (mol_error > self.molar_tolerance
-             or rmol_error > self.relative_molar_tolerance)
-        )
+                not_converged = (
+                    self.iter < self.maxiter and (mol_error > self.molar_tolerance
+                     or rmol_error > self.relative_molar_tolerance)
+                )
+            else:
+                not_converged = False
+        else:
+            not_converged = False
         return new_top_flow_rates, not_converged
 
 


### PR DESCRIPTION
This pull makes the following changes:

* Add SHGO (simplicial homology global optimization) as an option for minimizing the for gibb's free energy for LLE, which makes it as fast as VLE (so it now takes 1/10 of the time it used to). ~The default is still differential evolution because SHGO may fail to find phase equilibrium (so differential evolution is more robust).~ The new default is SHGO, but if it fails it falls back to differential evolution. 
* Use splines in multistage LLE when only 1 phase exists (this can happen while attempting to solve a large number of stages).
* Updates to documentation.
* Fix bug with separations.lle when top-chemical is not passed. It should make the top phase the one with lowest density by default, but it previously did not (we just got lucky that the LLE solver ended up that way). This fixes the behavior of a few single-stage LLE units in BioSTEAM when `top_chemical` is not passed (multi-stage equilibrium did not have any issues).
* Introduce SHGO algorithm as an option in VLE object.

Future work may introduce a VLLE object that uses SHGO/differential evolution to solve for all three phases at a time.
Thanks!
