### PR TITLE
Upgrade numba to 0.61.0 to support python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
                       'xlrd>=1.2.0',
                       'openpyxl>=3.0.0',
                       'flexsolve>=0.5.9',
-                      'numba==0.60.0',
+                      'numba==0.61.0',
                       'coolprop',
                       'imageio',
                       'pydot',


### PR DESCRIPTION
Even the most recent version of thermosteam (0.52.8) depends on numba == 0.60.0, but numba started supporting python 3.13 in 0.61.0.