### PR TITLE
Fix VLE.set_PH silently ignoring H spec for locked-phase-only streams

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -563,7 +563,41 @@ def test_vle_critical_pure_component():
     assert s.phase == 'g'
     s.vle(P=N2.Pc, S=s.S + 10)
     assert s.phase == 'g'
-    
+
+def test_vle_PH_locked_phase_only():
+    # A stream composed entirely of locked-phase chemicals (e.g. a permanent
+    # gas modeled with a fixed phase) has no chemicals eligible for VLE, so
+    # `VLE._setup` raises `NoEquilibrium` before `VLE._N` is (re)assigned.
+    # `VLE.set_PH`'s own `self._N == 0` branch already handles this case
+    # correctly (solving for T via a direct single-phase enthalpy balance),
+    # but was unreachable through this path -- `set_PH` used to silently
+    # leave the stream's temperature completely unchanged instead of
+    # raising or solving for the requested duty. Fixed in VLE.set_PH by
+    # catching NoEquilibrium from _setup and falling back to the same
+    # xsolve_T_at_HP call as the self._N == 0 branch.
+    H2 = tmo.Chemical('H2', phase='g', cache=True)
+    tmo.settings.set_thermo(
+        [H2, 'Water', 'Ethanol', 'Octane', 'Nonane', 'Decane',
+         'Dodecane', 'Hexadecane', 'Octadecane'], cache=True,
+    )
+    s = tmo.Stream(None, H2=1, units='kg/hr', T=638.15, P=7134008.172, phase='g')
+    s.vle(T=s.T, P=s.P)
+    H_start = s.H
+    T_start = s.T
+
+    # A modest, unambiguous heating request (T should increase).
+    target_H = H_start + 3705.25
+    s.vle(H=target_H, P=s.P)
+    assert_allclose(s.H, target_H, rtol=0, atol=1.)
+    assert s.T > T_start
+
+    # A modest cooling request too, for symmetry.
+    s.vle(T=T_start, P=s.P)
+    target_H = s.H - 3705.25
+    s.vle(H=target_H, P=s.P)
+    assert_allclose(s.H, target_H, rtol=0, atol=1.)
+    assert s.T < T_start
+
 if __name__ == '__main__':
     test_empty_chemical()
     test_registration_bypass()
@@ -577,6 +611,7 @@ if __name__ == '__main__':
     stream_methods()
     test_stream_property_cache()
     test_vle_critical_pure_component()
+    test_vle_PH_locked_phase_only()
     test_critical()
     test_mixture()
     test_mixing_phases()

--- a/thermosteam/equilibrium/vle.py
+++ b/thermosteam/equilibrium/vle.py
@@ -1133,10 +1133,26 @@ class VLE(Equilibrium, phases='lg'):
         self._S_hat = S_hat
     
     def set_PH(self, P, H, gas_conversion=None, liquid_conversion=None):
-        self._setup(gas_conversion, liquid_conversion)
+        try:
+            self._setup(gas_conversion, liquid_conversion)
+        except NoEquilibrium:
+            # `_setup` raises before `self._N` is (re)assigned whenever there
+            # is flow but none of it belongs to VLE-eligible chemicals (e.g.,
+            # a stream composed entirely of locked-phase chemicals), so the
+            # `self._N == 0` branch below is unreachable through the normal
+            # path for that case even though it already handles it correctly.
+            # `self._phase_data` is set unconditionally at the top of
+            # `_setup`, before either of its two `NoEquilibrium` raises, so
+            # it's safe to use here.
+            thermal_condition = self._thermal_condition
+            thermal_condition.P = self._P = P
+            thermal_condition.T = self.mixture.xsolve_T_at_HP(
+                self._phase_data, H, thermal_condition.T, P
+            )
+            return
         thermal_condition = self._thermal_condition
         thermal_condition.P = self._P = P
-        if self._N == 0: 
+        if self._N == 0:
             thermal_condition.T = self.mixture.xsolve_T_at_HP(
                 self._phase_data, H, thermal_condition.T, P
             )


### PR DESCRIPTION
## Summary

`VLE.set_PH` (used whenever `stream.vle(H=..., P=...)` is called) silently leaves the stream's temperature **completely unchanged** — no error, no warning — when the stream is composed entirely of locked-phase chemicals (e.g. a permanent gas modeled with `phase='g'`, like `H2` or `N2`).

## Root cause

`VLE._setup` raises `NoEquilibrium('no chemicals to perform equilibrium')` whenever a stream has real flow but none of it belongs to chemicals eligible for VLE (`mol_vle.any()` is `False` — this happens for a stream where every present chemical is locked-phase). This raise happens *before* `self._N` is ever (re)assigned.

`set_PH` already has correct handling for exactly this situation:

```python
if self._N == 0: 
    thermal_condition.T = self.mixture.xsolve_T_at_HP(
        self._phase_data, H, thermal_condition.T, P
    )
    return
```

But this branch is unreachable through the normal call path for the locked-phase-only case, because `self._setup(...)` (the line right above it) already raised before `self._N` could be set to `0`. The exception propagates up to `VLE.__call__`'s dispatch, which for the `P_spec and H_spec` case does:

```python
elif H_spec:
    try:
        self.set_PH(P, H, gas_conversion, liquid_conversion)
    except NoEquilibrium:
        thermal_condition = self._thermal_condition
        thermal_condition.P = P
```

— silently catching the exception and only ever assigning `P`, never solving for `T`. (For comparison, the equivalent `T_spec and P_spec` fallback is correct, since `T` is being assigned directly rather than solved for — this asymmetry is exactly why the bug is easy to miss.)

## Minimal reproduction

```python
import thermosteam as tmo

H2 = tmo.Chemical('H2', phase='g', cache=True)
tmo.settings.set_thermo(
    [H2, 'Water', 'Ethanol', 'Octane', 'Nonane', 'Decane',
     'Dodecane', 'Hexadecane', 'Octadecane'], cache=True,
)
s = tmo.Stream(None, H2=1, units='kg/hr', T=638.15, P=7134008.172, phase='g')
s.vle(T=s.T, P=s.P)

target_H = s.H + 3705.25  # a real heating request
s.vle(H=target_H, P=s.P)
print(s.T, s.H)  # BEFORE this fix: unchanged (638.15, original H) -- the request was silently dropped
                 # AFTER this fix: 667.15, H == target_H
```

Found while debugging a `HeatExchangerNetwork` synthesis crash in a downstream project ([QSDsan](https://github.com/QSD-Group/QSDsan)/[EXPOsan](https://github.com/QSD-Group/EXPOsan)): `biosteam.facilities.hxn.hxn_synthesis.synthesize_network`'s final utility-exchanger step builds a rigorous `HXutility(H=target, ...)` for a stream that happened to be pure H2 (locked-phase). Because the H2 stream's mid-network process-integration matches left it short of its target enthalpy, the utility step needed to add real additional duty — which this bug silently failed to do, producing a self-inconsistent state that later tripped an unrelated internal assertion in `hxn_synthesis.py`. The bug itself, however, is entirely local to `thermosteam` and reproducible without any BioSTEAM facility code, as above.

## Fix

Catch `NoEquilibrium` raised by `_setup` inside `set_PH` and fall back to the same `xsolve_T_at_HP` call the (otherwise unreachable in this case) `self._N == 0` branch already performs.

## Testing

- Added `test_vle_PH_locked_phase_only` to `tests/test_stream.py`, verifying both a heating and a cooling request against a locked-phase-only (pure H2) stream in a multi-chemical thermo package. Confirmed it fails on `master` (reproducing the exact silent no-op) and passes with the fix.
- Full existing test suite (`pytest tests/`) passes: 44/44 (43 pre-existing + the new one).
- `--doctest-modules` on the modified file (`thermosteam/equilibrium/vle.py`) shows one pre-existing, unrelated floating-point doctest flake (confirmed present identically on unmodified `master`, unaffected by this change).

`set_TH` (the T,H-given → solve-for-P direction) has an analogous `self._N == 0` branch, but it deliberately raises `RuntimeError` rather than solving — that looks like an intentional "not supported" case rather than the same bug, so I left it untouched. Happy to also address it here if that's not the case.