### PR TITLE
Fix VLE.set_PH when (vle) chemicals exist

### DIFF
--- a/thermosteam/equilibrium/vle.py
+++ b/thermosteam/equilibrium/vle.py
@@ -1133,10 +1133,13 @@ class VLE(Equilibrium, phases='lg'):
         self._S_hat = S_hat
     
     def set_PH(self, P, H, gas_conversion=None, liquid_conversion=None):
-        self._setup(gas_conversion, liquid_conversion)
+        try:
+            self._setup(gas_conversion, liquid_conversion)
+        except NoEquilibrium:
+            self._N = 0 # no chemicals or no vle chemicals
         thermal_condition = self._thermal_condition
         thermal_condition.P = self._P = P
-        if self._N == 0: 
+        if self._N == 0:
             thermal_condition.T = self.mixture.xsolve_T_at_HP(
                 self._phase_data, H, thermal_condition.T, P
             )


### PR DESCRIPTION
@yoelcortes 
Previously, when `NoEquilibrium` was raised for no chemicals/vle chemicals, `self._N` (would be 0 for these cases) was not set, so `set_PH` does resolve to the correct fix below:
```python
        if self._N == 0:
            thermal_condition.T = self.mixture.xsolve_T_at_HP(
                self._phase_data, H, thermal_condition.T, P
            )
            return
```

Note: the following block does set `thermal_condition` and `thermal_condition.P`, but not `thermal_condition.T`
```python
        elif P_spec:
            if V_spec:
                try:
                    self.set_PV(P, V, gas_conversion, liquid_conversion, wt=wt)
                except NoEquilibrium:
                    thermal_condition = self._thermal_condition
                    thermal_condition.P = P
            elif H_spec:
                try:
                    self.set_PH(P, H, gas_conversion, liquid_conversion)
                except NoEquilibrium:
                    thermal_condition = self._thermal_condition
                    thermal_condition.P = P
```

Similar issues might exist for `setup_PS` as well, thanks.